### PR TITLE
Firebase preview expiration and artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,10 +94,3 @@ jobs:
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TESTING_MAQUILA }}
           channelId: live
           projectId: testing-maquila
-
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-          compression-level: 9

--- a/.github/workflows/firebase-hosting-pr.yml
+++ b/.github/workflows/firebase-hosting-pr.yml
@@ -59,3 +59,4 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_TESTING_MAQUILA }}
           projectId: testing-maquila
+          expires: 3d


### PR DESCRIPTION
- Made previews expire in 3 days
- Disabled uploading artifacts, as they're not even used